### PR TITLE
feat: permitir que el admin pueda editar la contrasenna de un usuario

### DIFF
--- a/src/components/userForm.js
+++ b/src/components/userForm.js
@@ -25,6 +25,7 @@ function UserForm( {userInfo = { id: '', name: '', alias: '', location: '', phon
   const onSubmit = async (data) => {
     if (cookies.token) {
       try {
+        if (!data.encrypted_password) delete data.encrypted_password;
         await postNewClient(cookies.token, data, userInfo.id);
         navigate(`/${clientFront.urlClients}`);
       } catch (error) {
@@ -168,26 +169,29 @@ function UserForm( {userInfo = { id: '', name: '', alias: '', location: '', phon
                 }}
                 errors={errors}
               />
-              {
-                userInfo.name === '' ?
-                  <Input 
-                    name="Contraseña"
-                    label="encrypted_password"
-                    register={register}
-                    validation={{ 
-                      required: {
-                        value: true, 
-                        message: 'Este campo es obligatorio'
-                      }, 
-                      minLength: {
-                        value: 8, 
-                        message: 'La contraseña debe tener al menos 8 caracteres'
-                      }
-                    }}
-                    errors={errors}
-                  />
-                : null
-              }
+              <Input
+                name="Contraseña"
+                label="encrypted_password"
+                placeholder={userInfo.name ? texts.placeholders.password : ''}
+                register={register}
+                type="password"
+                validation={userInfo.name ? {
+                  minLength: {
+                    value: 8,
+                    message: 'La contraseña debe tener al menos 8 caracteres',
+                  }
+                } : {
+                  required: {
+                    value: true,
+                    message: 'Este campo es obligatorio',
+                  },
+                  minLength: {
+                    value: 8,
+                    message: 'La contraseña debe tener al menos 8 caracteres',
+                  }
+                }}
+                errors={errors}
+              />
               <button 
                 type="submit"
                 className="w-full bg-blue-500 text-white py-2 rounded-md hover:bg-blue-600"

--- a/src/texts/Clients/oneClients/EditClientText.json
+++ b/src/texts/Clients/oneClients/EditClientText.json
@@ -7,5 +7,8 @@
     },
     "buttons": {
       "submitButton": "Editar usuario"
+    },
+    "placeholders": {
+      "password": "Dejar en blanco si no se quiere editar la contraseña"
     }
   }


### PR DESCRIPTION
## Issues relacionados

[tarjeta](https://trello.com/c/C7AOojQ5)

## Descripción del problema (en caso de que no exista un issue que lo explique)

No estaba implementado la edición de la contraseña desde el front ni en el back.

Por requerimientos de negocios, esta lógica cambió. Se necesita que el admin sea el único que pueda editar todo, incluida la contraseña, y sin pedir la anterior. Esto dado que el admin puede olvidar la primera contraseña que creó, entonces simplemente le setea una nueva al usuario.

Ya está implementado en el back en este [PR](https://github.com/Emiliax16/WellProject/pull/23) no mergeado aun.

## Solución propuesta

Se añade el campo de contraseña al editar un usuario, el cual tiene el placeholder de "Dejar en blanco si no se quiere editar". Antes de enviar los datos al back, eliminamos el campo `encrypted_password` de la data si es que se dejó en blanco, ya que se guarda con `undefined`.

## Screenshots

![image](https://github.com/Emiliax16/WellProjectFront/assets/69869381/33ff986a-6faa-470b-b02b-6d6d11e0aa8d)

## Cómo probar

- correr `npm install`
- iniciar el servidor con `npm run start`
- se debe probar en conjunto con la rama del backend de este [PR](https://github.com/Emiliax16/WellProject/pull/23)
- crear un usuario
- en la vista de clientes, editar un usuario
- debería ver el campo de contraseña tanto al crear como al editar