### PR TITLE
feature: crear un navbar para mejorar experiencia de usuario

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -1,0 +1,202 @@
+// Link del componente: https://mui.com/material-ui/react-app-bar/
+import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import AppBar from '@mui/material/AppBar';
+import Box from '@mui/material/Box';
+import Toolbar from '@mui/material/Toolbar';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import Menu from '@mui/material/Menu';
+import MenuIcon from '@mui/icons-material/Menu';
+import Container from '@mui/material/Container';
+import Avatar from '@mui/material/Avatar';
+import Button from '@mui/material/Button';
+import Tooltip from '@mui/material/Tooltip';
+import MenuItem from '@mui/material/MenuItem';
+
+import navbarText from "../texts/components/navbarText.json";
+import Logo from "../assets/img/img5.webp";
+import { useAuth } from '../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
+
+function Navbar({ children }) {
+  const navigate = useNavigate();
+
+  // El navbar se renderiza en todas las vistas menos en los paths indicados
+  const location = useLocation();
+  const noNavbarPaths = ['/login', '/', '/telemetria'];
+
+  const { isAdmin, user, logout } = useAuth();
+
+  let pages = [];
+  const settings = [navbarText.settings.logout];
+
+  if (isAdmin) {
+    pages = [
+      { name: navbarText.pages.portalAdmin, path: '/admin' },
+      { name: navbarText.pages.clients, path: '/clients' }
+    ];
+  } else if (user && user.client) {
+    pages = [
+      { name: navbarText.pages.portalUser, path: `/clients/${user.client.id}` }
+    ];
+  }
+  
+  // Configuración para cuando se seleccionan las opciones del navbar
+  const [anchorElNav, setAnchorElNav] = useState(null);
+  const [anchorElUser, setAnchorElUser] = useState(null);
+
+  const handleOpenNavMenu = (event) => {
+    setAnchorElNav(event.currentTarget);
+  };
+
+  const handleOpenUserMenu = (event) => {
+    setAnchorElUser(event.currentTarget);
+  };
+
+  const handleCloseNavMenu = () => {
+    setAnchorElNav(null);
+  };
+
+  const handleCloseUserMenu = () => {
+    setAnchorElUser(null);
+  };
+
+  const handleMenuItemClick = (path) => {
+    handleCloseNavMenu();
+    navigate(path);
+  };
+
+  const handleLogout = () => {
+    handleCloseUserMenu();
+    logout();
+    navigate('/');
+  };
+
+  return (
+    <>
+      {!noNavbarPaths.includes(location.pathname.toLowerCase()) && (
+      <AppBar position="static">
+        <Container maxWidth="xl">
+          <Toolbar disableGutters>
+            <img src={Logo} alt="Logo" className="h-10 w-10 mx-2" />
+            <Typography
+              variant="h7"
+              noWrap
+              component="a"
+              sx={{
+                mr: 2,
+                display: { xs: 'none', md: 'flex' },
+                fontFamily: 'monospace',
+                fontWeight: 500,
+                letterSpacing: '.1rem',
+                color: 'inherit',
+                textDecoration: 'none',
+              }}
+            >
+               {navbarText.logo.title}
+            </Typography>
+
+            <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
+              <IconButton
+                size="large"
+                aria-label="account of current user"
+                aria-controls="menu-appbar"
+                aria-haspopup="true"
+                onClick={handleOpenNavMenu}
+                color="inherit"
+              >
+                <MenuIcon />
+              </IconButton>
+              <Menu
+                id="menu-appbar"
+                anchorEl={anchorElNav}
+                anchorOrigin={{
+                  vertical: 'bottom',
+                  horizontal: 'left',
+                }}
+                keepMounted
+                transformOrigin={{
+                  vertical: 'top',
+                  horizontal: 'left',
+                }}
+                open={Boolean(anchorElNav)}
+                onClose={handleCloseNavMenu}
+                sx={{
+                  display: { xs: 'block', md: 'none' },
+                }}
+              >
+                {pages.map((page) => (
+                  <MenuItem key={page.name} onClick={() => handleMenuItemClick(page.path)}>
+                    <Typography textAlign="center">{page.name}</Typography>
+                  </MenuItem>
+                ))}
+              </Menu>
+            </Box>
+            <Typography
+              variant="h7"
+              noWrap
+              component="a"
+              sx={{
+                mr: 2,
+                display: { xs: 'flex', md: 'none' },
+                flexGrow: 1,
+                fontFamily: 'monospace',
+                fontWeight:500,
+                letterSpacing: '.1rem',
+                color: 'inherit',
+                textDecoration: 'none',
+              }}
+            >
+              {navbarText.logo.title}
+            </Typography>
+            <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
+              {pages.map((page) => (
+                <Button
+                  key={page.name}
+                  onClick={() => handleMenuItemClick(page.path)}
+                  sx={{ my: 2, color: 'white', display: 'block' }}
+                >
+                  {page.name}
+                </Button>
+              ))}
+            </Box>
+
+            <Box sx={{ flexGrow: 0 }}>
+              <Tooltip title="Open settings">
+                <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
+                  <Avatar alt={user ? user.name : navbarText.logo.defaultName} src="/static/images/avatar/2.jpg" />
+                </IconButton>
+              </Tooltip>
+              <Menu
+                sx={{ mt: '45px' }}
+                id="menu-appbar"
+                anchorEl={anchorElUser}
+                anchorOrigin={{
+                  vertical: 'top',
+                  horizontal: 'right',
+                }}
+                keepMounted
+                transformOrigin={{
+                  vertical: 'top',
+                  horizontal: 'right',
+                }}
+                open={Boolean(anchorElUser)}
+                onClose={handleCloseUserMenu}
+              >
+                {settings.map((setting) => (
+                  <MenuItem key={setting} onClick={handleLogout}>
+                    <Typography textAlign="center">{setting}</Typography>
+                  </MenuItem>
+                ))}
+              </Menu>
+            </Box>
+          </Toolbar>
+        </Container>
+      </AppBar>
+      )}
+      {children}
+    </>
+  );
+}
+export default Navbar;

--- a/src/index.js
+++ b/src/index.js
@@ -23,76 +23,80 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
 import PrivateRoute from './components/PrivateRoute';
 
+import Navbar from './components/navbar';
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(  
   <React.StrictMode>
     <StyledEngineProvider injectFirst>
       <AuthProvider>
         <Router>
-          <Routes>
-            <Route path="/" element={<LandingPage />} />
-            <Route path="/telemetria" element={<Telemetria />} />
-            <Route path="/login" element={<Login />} />
-            <Route path="/test" element={<Test />} />
-            <Route path="/admin" element={
-              <PrivateRoute roles={['admin']}>
-                <Admin />
-              </PrivateRoute>
-            } />
-            <Route path="/view" element={<View />} />
+          <Navbar>
+            <Routes>
+              <Route path="/" element={<LandingPage />} />
+              <Route path="/telemetria" element={<Telemetria />} />
+              <Route path="/login" element={<Login />} />
+              <Route path="/test" element={<Test />} />
+              <Route path="/admin" element={
+                <PrivateRoute roles={['admin']}>
+                  <Admin />
+                </PrivateRoute>
+              } />
+              <Route path="/view" element={<View />} />
 
-            {/* Clientes */}
-            {/* Crear */}
-            <Route path="/clients/new" element={
-              <PrivateRoute roles={['admin']}>
-                <NewClient />
-              </PrivateRoute>
-            } />
-            {/* Ver todos*/}
-            <Route path="/clients" element={
-              <PrivateRoute roles={['admin']}>
-                <ClientList />
-              </PrivateRoute>
-            } />
-            {/* Ver uno*/}
-            <Route path="/clients/:id" element={<ClientDetails />} />
-            {/* Crear un pozo */}
-            <Route path="/clients/:id/wells/new" element={
-              <PrivateRoute roles={['admin']}>
-                <CreateWell />
-              </PrivateRoute>
-            } />
-            {/* Editar un cliente */}
-            <Route path="/clients/:id/edit" element={
-              <PrivateRoute roles={['admin']}>
-                <EditClient />
-              </PrivateRoute>            
-            } />
-            {/* Eliminar un cliente */}
-            <Route path="/clients/:id/delete" element={
-              <PrivateRoute roles={['admin']}>
-                <DeleteClient />
-              </PrivateRoute>
-            } />
-            {/* Ver pozos */}
-            <Route path="/clients/:id/wells" element={<ClientWells />} />
-            {/* Ver reportes de un pozo */}
-            <Route path="/clients/:clientId/wells/:code" element={<WellReportList />} />
-            {/* Editar un pozo */}
-            <Route path="/clients/:id/wells/:code/edit" element={
-              <PrivateRoute roles={['admin']}>
-                <EditWell />
-              </PrivateRoute>
-            } 
-            />
-            {/* Eliminar un pozo */}
-            <Route path="/clients/:id/wells/:code/delete" element={
-              <PrivateRoute roles={['admin']}>
-                <DeleteWell />
-              </PrivateRoute>
-            } />
-            <Route path="/*" element="404 Not Found" />
-          </Routes>
+              {/* Clientes */}
+              {/* Crear */}
+              <Route path="/clients/new" element={
+                <PrivateRoute roles={['admin']}>
+                  <NewClient />
+                </PrivateRoute>
+              } />
+              {/* Ver todos*/}
+              <Route path="/clients" element={
+                <PrivateRoute roles={['admin']}>
+                  <ClientList />
+                </PrivateRoute>
+              } />
+              {/* Ver uno*/}
+              <Route path="/clients/:id" element={<ClientDetails />} />
+              {/* Crear un pozo */}
+              <Route path="/clients/:id/wells/new" element={
+                <PrivateRoute roles={['admin']}>
+                  <CreateWell />
+                </PrivateRoute>
+              } />
+              {/* Editar un cliente */}
+              <Route path="/clients/:id/edit" element={
+                <PrivateRoute roles={['admin']}>
+                  <EditClient />
+                </PrivateRoute>            
+              } />
+              {/* Eliminar un cliente */}
+              <Route path="/clients/:id/delete" element={
+                <PrivateRoute roles={['admin']}>
+                  <DeleteClient />
+                </PrivateRoute>
+              } />
+              {/* Ver pozos */}
+              <Route path="/clients/:id/wells" element={<ClientWells />} />
+              {/* Ver reportes de un pozo */}
+              <Route path="/clients/:clientId/wells/:code" element={<WellReportList />} />
+              {/* Editar un pozo */}
+              <Route path="/clients/:id/wells/:code/edit" element={
+                <PrivateRoute roles={['admin']}>
+                  <EditWell />
+                </PrivateRoute>
+              } 
+              />
+              {/* Eliminar un pozo */}
+              <Route path="/clients/:id/wells/:code/delete" element={
+                <PrivateRoute roles={['admin']}>
+                  <DeleteWell />
+                </PrivateRoute>
+              } />
+              <Route path="/*" element="404 Not Found" />
+            </Routes>
+          </Navbar>
         </Router>
       </AuthProvider>
     </StyledEngineProvider>

--- a/src/texts/components/navbarText.json
+++ b/src/texts/components/navbarText.json
@@ -1,0 +1,14 @@
+{
+    "pages": {
+      "portalAdmin": "Portal Admin",
+      "clients": "Clientes",
+      "portalUser": "Portal Usuario"
+    },
+    "settings": {
+      "logout": "Cerrar Sesión"
+    },
+    "logo": {
+        "title": "PROMEDICIÓN",
+        "defaultName": "Juan"
+    }
+  }

--- a/src/views/Admin/Admin.js
+++ b/src/views/Admin/Admin.js
@@ -9,7 +9,6 @@ function Admin() {
 
   return (
     <div>
-      <div className='bg-indigo-700 text-xl text-center text-slate-200'>This should be protected </div>
       {
         user ? 
           <div className='bg-green-500 text-white p-2'>Welcome {user.name} ({user.roleId === 1 ? 'admin' : 'regular'})</div> : 


### PR DESCRIPTION
## Issues relacionados

[tarjeta](https://trello.com/c/eh0YNhOO)

## Descripción del problema (en caso de que no exista un issue que lo explique)

Cuando se realizaban acciones tanto para admin como para usuario normal, era dificil volver a la página principal, y solo se podía hacer mediante el "atras" del navegador. Además, solo el admin se podía desloggear.

## Solución propuesta

Se crea un navbar que diferencia usuario admin de usuario normal, de tal manera que el admin tendrá acceso directo a la vista `/admin` (portal admin) y a la vista `/clients` (clientes); mientras que el usuario normal tendrá acceso a la vista `/clients/id` (portal usuario). Ambos tendrán la posibilidad de desloggearse desde cualquier vista.

## Screenshots

![image](https://github.com/user-attachments/assets/c8a365e5-eb5f-434e-9182-501120f7b72a)
![image](https://github.com/user-attachments/assets/39959cd9-b123-47ea-99cd-2c9ee8e6c7fa)

## Cómo probar

- tener actualizados ambos repositorios (back y front)
- en el repo back, levantar el servidor con `npm run dev`
- en el repo front, movernos a esta rama y levantar el servidor con `npm start`
- loggearse con usuario admin y uno normal y probar las funcionalidades nuevas del navbar.
