### PR TITLE
fix(services): enviar Authorization en header HTTP, no en body

### DIFF
--- a/src/services/clientServices.js
+++ b/src/services/clientServices.js
@@ -117,17 +117,15 @@ const postNewClient = async (token, data, clientId) => {
   try {
     let response = null;
     if (clientId === '') {
-      response = await apiClient.post(`${postUser}` , {
-        ...data,
+      response = await apiClient.post(`${postUser}`, data, {
         headers: {
           Authorization: `Bearer ${token}`
         }
       });
-    } 
+    }
     else {
       const url = `${putClient}/${clientId}/edit`
-      response = await apiClient.put(url , {
-        ...data,
+      response = await apiClient.put(url, data, {
         headers: {
           Authorization: `Bearer ${token}`
         }

--- a/src/services/companyServices.js
+++ b/src/services/companyServices.js
@@ -37,17 +37,15 @@ const postNewCompany = async (token, data, companyId) => {
   try {
     let response = null;
     if (companyId === '') {
-      response = await apiClient.post(`${postUser}` , {
-        ...data,
+      response = await apiClient.post(`${postUser}`, data, {
         headers: {
           Authorization: `Bearer ${token}`
         }
       });
-    } 
+    }
     else {
       const url = `${putCompany}/${companyId}/edit`
-      response = await apiClient.put(url , {
-        ...data,
+      response = await apiClient.put(url, data, {
         headers: {
           Authorization: `Bearer ${token}`
         }

--- a/src/services/distributorService.js
+++ b/src/services/distributorService.js
@@ -42,16 +42,14 @@ const postNewDistributor = async (token, data, distributorId) => {
   try {
     let response = null;
     if (distributorId === "") {
-      response = await apiClient.post(`${postUser}`, {
-        ...data,
+      response = await apiClient.post(`${postUser}`, data, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
       });
     } else {
       const url = `${putDistributor}/${distributorId}/edit`;
-      response = await apiClient.put(url, {
-        ...data,
+      response = await apiClient.put(url, data, {
         headers: {
           Authorization: `Bearer ${token}`,
         },

--- a/src/services/wellServices.js
+++ b/src/services/wellServices.js
@@ -6,12 +6,12 @@ const { statusWell } = wellBack;
 const activateWell = async (token, wellId) => {
     try {
       const url = `${statusWell}/${wellId}/active`
-      const response = await apiClient.put(url, {
+      const response = await apiClient.put(url, {}, {
         headers: {
           Authorization: `Bearer ${token}`
         }
       });
-  
+
       return response.data;
     } catch (error) {
       throw error;


### PR DESCRIPTION
## Contexto

Cuatro services usaban la firma de 2 argumentos de axios
\`apiClient.post(url, body)\` y \`apiClient.put(url, body)\`, mezclando el
header Authorization dentro del body como
\`{ ...data, headers: { Authorization } }\`. Eso convertía el token Bearer
en un campo JSON del body en vez de un header HTTP real.

El backend tenía un workaround para leer el token desde
\`req.body.headers.Authorization\`, pero ese workaround crasheaba con
\`Cannot read properties of undefined (reading 'Authorization')\` cuando
llegaba un request GET sin body o sin auth (visible en logs de
/companies y /clients).

El workaround del backend se elimina en
**Emiliax16/WellProject#54** (\`fix/p0-stability-hardening\`), commit
\`fix(auth): read bearer token only from Authorization HTTP header\`.

Este PR alinea el frontend con la API estándar.

## Cambios (4 commits)

| # | Commit | Endpoints |
|---|---|---|
| 1 | \`fix(services): send Authorization via HTTP header in companyServices\` | POST crear company, PUT editar company |
| 2 | \`fix(services): send Authorization via HTTP header in distributorService\` | POST crear distributor, PUT editar distributor |
| 3 | \`fix(services): send Authorization via HTTP header in clientServices\` | POST crear client, PUT editar client |
| 4 | \`fix(services): send Authorization via HTTP header in wellServices\` | PUT activar/desactivar well |

En todos los casos el cambio es el mismo:

\`\`\`diff
- apiClient.post(url, {
-   ...data,
-   headers: { Authorization: \`Bearer \${token}\` }
- });
+ apiClient.post(url, data, {
+   headers: { Authorization: \`Bearer \${token}\` }
+ });
\`\`\`

El resto de los métodos en estos archivos (todos los GET y DELETE, además
de \`postNewWell\`/\`putNewWell\` en clientServices) **ya usaban el patrón
correcto**, así que esto es alineación, no introducción de un patrón
nuevo.

## Caso especial: \`wellServices.activateWell\`

Antes enviaba \`{ headers: { Authorization } }\` como body único — un body
con un solo campo "headers" sin sentido para el endpoint. El endpoint
\`PUT /wells/:id/active\` en el backend hace toggle de \`isActived\` sin
leer el body, así que funcionaba por casualidad. Ahora se manda
\`apiClient.put(url, {}, { headers })\` con body vacío explícito,
consistente con el contrato del endpoint y sin cambiar comportamiento
visible.

## Coordinación con el backend ⚠️

Este PR debe **mergearse y desplegarse antes** que
**Emiliax16/WellProject#54**. Razón: el backend actual en producción
soporta ambos formatos (legacy body + header HTTP). Cuando el PR del
backend se despliegue, solo aceptará el header HTTP. Si el frontend no
está actualizado, los 7 endpoints listados arriba dejarán de
autenticarse.

## Test plan

- [ ] Build local del frontend (\`npm run build\`)
- [ ] Inspector de red en el browser: confirmar que las requests POST/PUT a
  \`/users/register\`, \`/companies/:id/edit\`, \`/distributors/:id/edit\`,
  \`/clients/:id/edit\` y \`/wells/:id/active\` envían el header HTTP
  \`Authorization: Bearer ...\` y NO incluyen \`headers\` dentro del body JSON
- [ ] Crear company → 200
- [ ] Editar company → 200
- [ ] Crear distributor → 200
- [ ] Editar distributor → 200
- [ ] Crear client → 200
- [ ] Editar client → 200
- [ ] Activar/desactivar well → 200

## Riesgos

Bajo, siempre que se respete el orden de despliegue (frontend antes que
backend). El backend actual sigue soportando el formato viejo, así que
durante la ventana intermedia (frontend nuevo + backend viejo) todo
sigue funcionando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)