### PR TITLE
fix: enviar el token de sesión al enviar y borrar reportes de un pozo

### DIFF
--- a/src/services/wellDataServices.js
+++ b/src/services/wellDataServices.js
@@ -3,13 +3,14 @@ import { wellDataBack } from '../utils/routes.utils';
 
 const { sendWellData } = wellDataBack;
 
-const sendReports = async (reports) => {
+const sendReports = async (token, reports) => {
   try {
     const reportIds = reports.map(report => report.id);
     const url = `${sendWellData}`;
     const response = await apiClient.post(
       url,
       { reportIds },
+      { headers: { Authorization: `Bearer ${token}` } }
     );
 
     return response.data;
@@ -18,11 +19,12 @@ const sendReports = async (reports) => {
   }
 };
 
-const bulkDeleteReports = async (reportIds) => {
+const bulkDeleteReports = async (token, reportIds) => {
   try {
     const url = '/wellData/bulk';
     const response = await apiClient.delete(url, {
-      data: { reportIds }
+      data: { reportIds },
+      headers: { Authorization: `Bearer ${token}` }
     });
 
     return response.data;

--- a/src/views/Clients/wellClients/reports/WellReportList.js
+++ b/src/views/Clients/wellClients/reports/WellReportList.js
@@ -119,7 +119,7 @@ function WellReportList() {
         }
       }
 
-      await sendReports(reportsToSend)
+      await sendReports(cookies.token, reportsToSend)
       setSelectedReports([])
       fetchWellReports()
     } catch (error) {
@@ -197,7 +197,7 @@ function WellReportList() {
       setDeletingReports(true)
       setError(null)
 
-      await bulkDeleteReports(selectedReports)
+      await bulkDeleteReports(cookies.token, selectedReports)
       
       setSelectedReports([])
       fetchWellReports()


### PR DESCRIPTION
## Issues relacionados

Sin ticket de Jira asociado.

Es el prerequisito de **Emiliax16/WellProject#56**, que cierra los endpoints
correspondientes en el backend. Este PR va primero.

## Descripción del problema: dos acciones destructivas del portal viajan sin autenticar

`sendReports` y `bulkDeleteReports` en `src/services/wellDataServices.js` son las únicas llamadas
del portal que no mandan el header `Authorization`. No fue un olvido con consecuencias hasta ahora:
los endpoints que consumen (`POST /repostAllReportsToDGA` y `DELETE /wellData/bulk`) están abiertos
en el backend, así que funcionaban igual.

El backend deja de aceptarlas sin sesión. El borrado masivo de reportes sin autenticación es un
agujero real: permite destruir telemetría que alimenta un reporte regulatorio. Cerrarlo del lado del
backend obliga a que el portal mande el token.

Sin este PR, ambas acciones responderían 401 en cuanto se despliegue el backend.

## Solución propuesta: pasar el token como primer argumento, igual que el resto de los services

El cambio es mecánico y sigue la convención ya establecida en `clientServices`, `companyServices` y
los demás: el token entra como primer parámetro y sale como header HTTP.

```diff
-const sendReports = async (reports) => {
+const sendReports = async (token, reports) => {
   const response = await apiClient.post(
     url,
     { reportIds },
+    { headers: { Authorization: `Bearer ${token}` } }
   );
```

En `bulkDeleteReports` el header se suma al objeto de configuración que ya existía para mandar
`data`, porque `apiClient.delete` lleva el body dentro de la config y no como segundo argumento.

La vista `WellReportList` ya tenía el token disponible en `cookies.token` y lo usa para el resto de
sus llamadas, así que solo se lo pasa a estas dos.

Vale la pena notar la diferencia con **#38**, que sigue abierto: ese PR corrige services que mandaban
el token *dentro del body* por usar la firma de 2 argumentos de axios. Acá el token no se mandaba de
ninguna forma. Son problemas distintos y los archivos no se pisan.

## Screenshots

No aplica, no hay cambios visuales.

## Cómo probar

**1. Build**

```bash
npm run build
```

**2. Verificar el header en el inspector de red**

Levantar el portal (`npm start`) contra un backend local, entrar a la vista de reportes de un pozo y
abrir la pestaña Network:

- Enviar reportes a la DGA → el `POST /repostAllReportsToDGA` debe llevar
  `Authorization: Bearer ...` en **Request Headers**.
- Seleccionar reportes y borrarlos → el `DELETE /wellData/bulk` debe llevar el mismo header, y
  mantener `{"reportIds":[...]}` en el body.

**3. Verificar que funciona contra los dos backends**

Esta es la parte que importa para el orden de despliegue:

- Contra `master` del backend (sin el PR de seguridad): ambas acciones deben seguir dando 200. El
  backend viejo ignora el header, así que no hay regresión.
- Contra la rama `fix/exposicion-de-datos-en-endpoints-publicos`: ambas deben dar 200. Sin este PR
  darían 401.

**Verificación ya hecha**

`npm run build` pasa y eslint no reporta nada sobre los dos archivos tocados. No probé el flujo en el
browser, así que el paso 2 y el 3 quedan de tu lado.

## Orden de despliegue: este PR primero

Este PR es compatible hacia atrás: manda un header que el backend actual simplemente ignora. Por eso
puede desplegarse solo, sin coordinar nada, y conviene hacerlo antes de tocar el backend.

Recién después va **Emiliax16/WellProject#56**. Al revés, el portal queda con el envío a
la DGA y el borrado de reportes caídos hasta que el frontend suba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
